### PR TITLE
Fix log reference in liquidsoap and presets syntax

### DIFF
--- a/server/liquidsoap/main.liq
+++ b/server/liquidsoap/main.liq
@@ -55,7 +55,7 @@ to3 = ref(silence)
 # Function to create mixes based on plan
 # Returns: (to1, to2, to3)
 def get_mixes(plan)
-  log("info", "Getting plan: #{x['title']} mix")
+  log("info", "Getting plan: #{plan} mix")
   if plan == "A1" then
     # 1 hears 2, 2 hears 3, 3 hears 1
     [s2_proc, s3_proc, s1_proc]

--- a/server/liquidsoap/presets.liq
+++ b/server/liquidsoap/presets.liq
@@ -38,8 +38,8 @@ let sculpture_crossfade = crossfade(
 )
 
 # Smart fallback with logging when fallback sources become active
-let sculpture_fallback = fun(id, sources) ->
-  def rec wrap(idx, items)
+def sculpture_fallback(id, sources) =
+  def rec wrap(idx, items) =
     if items == [] then []
     else
       src  = list.hd(items)
@@ -61,6 +61,7 @@ let sculpture_fallback = fun(id, sources) ->
     track_sensitive=false,
     wrap(1, sources)
   )
+end
 
 # Volume control function
 let sculpture_volume = fun(vol, s) ->


### PR DESCRIPTION
## Summary
- fix logging in Liquidsoap script by using `plan`
- correct `sculpture_fallback` definition so presets parse properly

## Testing
- `liquidsoap --parse-only server/liquidsoap/presets.liq`


------
https://chatgpt.com/codex/tasks/task_e_684058de7cec8331bbb305ba610fa987