### PR TITLE
Fix syntax error in Liquidsoap fallback

### DIFF
--- a/server/liquidsoap/presets.liq
+++ b/server/liquidsoap/presets.liq
@@ -52,7 +52,6 @@ def sculpture_fallback(id, sources) =
         else
           src
         end
-      end
       logged :: wrap(idx + 1, rest)
     end
   end


### PR DESCRIPTION
## Summary
- remove an extra `end` in `presets.liq` that caused Liquidsoap to fail parsing

## Testing
- `liquidsoap --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840616ae7b883319ffe09e4a02e87b3