### PR TITLE
Fix fallback recursion syntax

### DIFF
--- a/server/liquidsoap/presets.liq
+++ b/server/liquidsoap/presets.liq
@@ -39,7 +39,7 @@ let sculpture_crossfade = crossfade(
 
 # Smart fallback with logging when fallback sources become active
 def sculpture_fallback(id, sources) =
-  def rec wrap(idx, items) =
+  def wrap(idx, items) =
     if items == [] then []
     else
       src  = list.hd(items)
@@ -52,7 +52,6 @@ def sculpture_fallback(id, sources) =
         else
           src
         end
-      end
       logged :: wrap(idx + 1, rest)
     end
   end


### PR DESCRIPTION
## Summary
- correct function definition for `wrap` in `sculpture_fallback`

## Testing
- `liquidsoap --check server/liquidsoap/presets.liq` *(fails: Missing arguments in function application)*

------
https://chatgpt.com/codex/tasks/task_e_6840616ae7b883319ffe09e4a02e87b3