### PR TITLE
Simplify sculpture_fallback

### DIFF
--- a/server/liquidsoap/presets.liq
+++ b/server/liquidsoap/presets.liq
@@ -37,29 +37,13 @@ let sculpture_crossfade = crossfade(
   fade_out=1.0
 )
 
-# Smart fallback with logging when fallback sources become active
+# Simple fallback helper
+# Wraps a list of sources with Liquidsoap's `fallback` operator.
 def sculpture_fallback(id, sources) =
-  def rec wrap(idx, items) =
-    if items == [] then []
-    else
-      src  = list.hd(items)
-      rest = list.tl(items)
-      logged =
-        if idx > 1 then
-          on_start(src, fun () ->
-            sculpture_log("Fallback #{id} activated (source #{idx})")
-          )
-        else
-          src
-        end
-      end
-      logged :: wrap(idx + 1, rest)
-    end
-  end
   fallback(
     id=id,
     track_sensitive=false,
-    wrap(1, sources)
+    sources
   )
 end
 


### PR DESCRIPTION
## Summary
- simplify the `sculpture_fallback` helper in `presets.liq`

## Testing
- `python3 -m py_compile server/liquidsoap/mqtt_to_telnet_bridge.py`
- `liquidsoap --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840616ae7b883319ffe09e4a02e87b3