### PR TITLE
Improve mode display

### DIFF
--- a/server/nodered/flow.json
+++ b/server/nodered/flow.json
@@ -767,7 +767,7 @@
         "gtype": "gage",
         "title": "Mode",
         "label": "",
-        "format": "{{value}}",
+        "format": "{{value === 1 ? 'Live' : 'Local'}}",
         "min": 0,
         "max": "1",
         "colors": [
@@ -895,7 +895,7 @@
         "gtype": "gage",
         "title": "Mode",
         "label": "",
-        "format": "{{value}}",
+        "format": "{{value === 1 ? 'Live' : 'Local'}}",
         "min": 0,
         "max": "1",
         "colors": [
@@ -1023,7 +1023,7 @@
         "gtype": "gage",
         "title": "Mode",
         "label": "",
-        "format": "{{value}}",
+        "format": "{{value === 1 ? 'Live' : 'Local'}}",
         "min": 0,
         "max": "1",
         "colors": [


### PR DESCRIPTION
## Summary
- adjust Node-RED dashboard gauges to show `Live`/`Local` rather than `1`/`0`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406edb2888833190adf46c6c0e4e8d