### PR TITLE
Add mode switching to plan buttons

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -197,7 +197,7 @@ sudo journalctl -u liquidsoap -f
 **From Windows:**
 1. Open web browser. The Node-RED dashboard is often at `http://YOUR_WSL_IP:1880/ui`. If this path does not work, try `http://YOUR_WSL_IP:1880/dashboard` or `http://YOUR_WSL_IP:1880/api/ui/`. The Node-RED flow editor (usually at `http://YOUR_WSL_IP:1880/` or `http://YOUR_WSL_IP:1880/admin/`) typically has a sidebar tab for 'dashboard' with a direct launch button.
 2. You should see the sculpture control dashboard.
-3. Test volume sliders and mode/plan switches
+3. Test volume sliders and mode/plan switches. Selecting plans A1–C now sends `{"mode":"live"}` and Plan D sends `{"mode":"local"}` so the players automatically switch modes.
 
 **From WSL:**
 ```bash

--- a/server/nodered/flow.json
+++ b/server/nodered/flow.json
@@ -384,7 +384,7 @@
         "type": "function",
         "z": "sculpture_dashboard",
         "name": "Format Plan Command",
-        "func": "var plan = msg.payload;\nmsg.payload = {\"plan\": plan};\nreturn msg;",
+        "func": "var plan = msg.payload;\nvar mode = (plan === 'D') ? 'local' : 'live';\nmsg.payload = {\"plan\": plan, \"mode\": mode};\nreturn msg;",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",


### PR DESCRIPTION
## Summary
- modify the plan format function so each plan button publishes a mode
- document new automatic mode switching in quickstart guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840662616d88331990c238c33486c58