### PR TITLE
Fix dynamic plan switching and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sculpture Audio System
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ ip addr show eth0
 
 ## License
 
-This project is open source. See individual component licenses for details.
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## Support
 

--- a/server/liquidsoap/main.liq
+++ b/server/liquidsoap/main.liq
@@ -47,10 +47,17 @@ prerecorded = sine(440.0)
 # Reference to current plan (default: B1)
 current_plan = ref("B1")
 
+
 # Mix output references updated when the plan changes
-to1 = ref(silence)
-to2 = ref(silence)
-to3 = ref(silence)
+# These hold the current audio mix for each sculpture.
+to1_ref = ref(silence)
+to2_ref = ref(silence)
+to3_ref = ref(silence)
+
+# Dynamic sources that will follow the value stored in the refs above
+to1 = source.of_ref(to1_ref)
+to2 = source.of_ref(to2_ref)
+to3 = source.of_ref(to3_ref)
 
 
 # Function to create mixes based on plan
@@ -86,9 +93,9 @@ end
 # Update mix references based on the current plan
 def update_mixes()
   mixes = get_mixes(!current_plan)
-  to1 := list.hd(mixes)
-  to2 := list.hd(list.tl(mixes))
-  to3 := list.hd(list.tl(list.tl(mixes)))
+  to1_ref := list.hd(mixes)
+  to2_ref := list.hd(list.tl(mixes))
+  to3_ref := list.hd(list.tl(list.tl(mixes)))
 end
 
 # Telnet command to set plan
@@ -132,7 +139,7 @@ output.icecast(
   mount="mix-for-1.ogg",
   name="Mix for Sculpture 1",
   description="Personalized audio mix",
-  !to1
+  to1
 )
 
 output.icecast(
@@ -143,7 +150,7 @@ output.icecast(
   mount="mix-for-2.ogg",
   name="Mix for Sculpture 2",
   description="Personalized audio mix",
-  !to2
+  to2
 )
 
 output.icecast(
@@ -154,7 +161,7 @@ output.icecast(
   mount="mix-for-3.ogg",
   name="Mix for Sculpture 3",
   description="Personalized audio mix",
-  !to3
+  to3
 )
 
 # Log startup

--- a/server/liquidsoap/mqtt_to_telnet_bridge.service
+++ b/server/liquidsoap/mqtt_to_telnet_bridge.service
@@ -5,8 +5,8 @@ After=network.target
 [Service]
 Type=simple
 User=unix_user
-WorkingDirectory=/c/Users/user/source/repos/yaga2025sculptures/server/liquidsoap
-ExecStart=/usr/bin/python3 /c/Users/user/source/repos/yaga2025sculptures/server/liquidsoap/mqtt_to_telnet_bridge.py
+WorkingDirectory=/opt/sculpture-system/liquidsoap
+ExecStart=/usr/bin/python3 /opt/sculpture-system/liquidsoap/mqtt_to_telnet_bridge.py
 Restart=on-failure
 RestartSec=5
 

--- a/server/nodered/flow.json
+++ b/server/nodered/flow.json
@@ -988,7 +988,7 @@
         "z": "sculpture_dashboard",
         "name": "Plan Button Logic",
         "func": "// Plan button IDs and their labels\nvar plans = [\n    {id: 'plan_btn_a1', value: 'A1'},\n    {id: 'plan_btn_a2', value: 'A2'},\n    {id: 'plan_btn_b1', value: 'B1'},\n    {id: 'plan_btn_b2', value: 'B2'},\n    {id: 'plan_btn_b3', value: 'B3'},\n    {id: 'plan_btn_c', value: 'C'},\n    {id: 'plan_btn_d', value: 'D'}\n];\n\n// Find which button was pressed\nvar selectedPlan = plans.find(p => p.value === msg.payload);\nif (selectedPlan) {\n    // Store the current plan in flow context\n    flow.set('currentPlan', selectedPlan.value);\n    // Send plan to plan_format\n    var planMsg = {payload: selectedPlan.value};\n    // Update button highlights\n    var uiControlMsgs = plans.map(p => {\n        return {\n            ui_control: {\n                bgColor: (p.id === selectedPlan.id) ? 'deepskyblue' : 'lightgray',\n                color: (p.id === selectedPlan.id) ? 'white' : 'black'\n            },\n            payload: p.value,\n            topic: p.id\n        };\n    });\n    // Output: [planMsg, ...uiControlMsgs]\n    return [planMsg, ...uiControlMsgs];\n}\nreturn [null, null, null, null, null, null, null];\n",
-        "outputs": 7,
+        "outputs": 8,
         "x": 400,
         "y": 480,
         "wires": [

--- a/server/nodered/flows/flow_system.json
+++ b/server/nodered/flows/flow_system.json
@@ -25,7 +25,7 @@
         "z": "sculpture_dashboard",
         "name": "Plan Button Logic",
         "func": "// Plan button IDs and their labels\nvar plans = [\n    {id: 'plan_btn_a1', value: 'A1'},\n    {id: 'plan_btn_a2', value: 'A2'},\n    {id: 'plan_btn_b1', value: 'B1'},\n    {id: 'plan_btn_b2', value: 'B2'},\n    {id: 'plan_btn_b3', value: 'B3'},\n    {id: 'plan_btn_c', value: 'C'},\n    {id: 'plan_btn_d', value: 'D'}\n];\n\n// Find which button was pressed\nvar selectedPlan = plans.find(p => p.value === msg.payload);\nif (selectedPlan) {\n    // Store the current plan in flow context\n    flow.set('currentPlan', selectedPlan.value);\n    // Send plan to plan_format\n    var planMsg = {payload: selectedPlan.value};\n    // Update button highlights\n    var uiControlMsgs = plans.map(p => {\n        return {\n            ui_control: {\n                bgColor: (p.id === selectedPlan.id) ? 'deepskyblue' : 'lightgray',\n                color: (p.id === selectedPlan.id) ? 'white' : 'black'\n            },\n            payload: p.value,\n            topic: p.id\n        };\n    });\n    // Output: [planMsg, ...uiControlMsgs]\n    return [planMsg, ...uiControlMsgs];\n}\nreturn [null, null, null, null, null, null, null];\n",
-        "outputs": 7,
+        "outputs": 8,
         "x": 400,
         "y": 480,
         "wires": [["plan_format"], ["plan_btn_a1"], ["plan_btn_a2"], ["plan_btn_b1"], ["plan_btn_b2"], ["plan_btn_b3"], ["plan_btn_c"], ["plan_btn_d"]]


### PR DESCRIPTION
## Summary
- allow Liquidsoap outputs to track new mixes via `source.of_ref`
- correct Plan Button Logic output count
- regenerate combined Node-RED flow
- use portable paths in `mqtt_to_telnet_bridge.service`
- add MIT license and reference from README

## Testing
- `node server/nodered/combine_flows.js`
- `python3 -m py_compile server/liquidsoap/mqtt_to_telnet_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_684578dfd2688331b9491baa18ae883e