### PR TITLE
Add MQTT bridge service deployment

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -125,6 +125,9 @@ node -v   # Should print a recent LTS version (18+)
 
 ## Step 10: Install Control Node Services
 
+This playbook also deploys the MQTT-to-Telnet bridge service used for
+dynamic plan switching. The bridge runs under the dedicated `unix` user.
+
 ```bash
 # In WSL Ubuntu terminal, ensure you are in your project directory
 # cd /path/to/your/yaga2025sculptures
@@ -140,6 +143,7 @@ sudo systemctl status icecast2
 sudo systemctl status mosquitto
 sudo systemctl status liquidsoap
 sudo systemctl status node-red
+sudo systemctl status mqtt_to_telnet_bridge
 ```
 
 **Troubleshooting after Ansible Playbook:**

--- a/server/ansible/install_control_node.yml
+++ b/server/ansible/install_control_node.yml
@@ -26,6 +26,7 @@
           - mosquitto
           - mosquitto-clients
           - nodejs
+          - python3-pip
         state: present
 
     - name: Install Node-RED globally
@@ -42,6 +43,12 @@
     - name: Create shared loops directory
       file:
         path: "{{ sculpture_dir }}/shared-loops"
+        state: directory
+        mode: '0755'
+
+    - name: Create liquidsoap scripts directory
+      file:
+        path: "{{ sculpture_dir }}/liquidsoap"
         state: directory
         mode: '0755'
 
@@ -153,6 +160,14 @@
         home: /opt/sculpture-system
         create_home: no
 
+    - name: Create unix user for MQTT bridge
+      user:
+        name: unix
+        system: yes
+        shell: /bin/false
+        home: /opt/sculpture-system
+        create_home: no
+
     - name: Copy Node-RED flow configuration
       copy:
         src: ../nodered/flow.json
@@ -210,6 +225,27 @@
         group: node-red
         recurse: yes
 
+    - name: Copy MQTT to Telnet bridge script
+      copy:
+        src: ../liquidsoap/mqtt_to_telnet_bridge.py
+        dest: "{{ sculpture_dir }}/liquidsoap/mqtt_to_telnet_bridge.py"
+        mode: '0755'
+        owner: unix
+        group: unix
+
+    - name: Install MQTT bridge Python dependencies
+      pip:
+        requirements: ../liquidsoap/requirements.txt
+
+    - name: Copy MQTT to Telnet bridge service
+      copy:
+        src: ../liquidsoap/mqtt_to_telnet_bridge.service
+        dest: /etc/systemd/system/mqtt_to_telnet_bridge.service
+        mode: '0644'
+      notify:
+        - reload systemd
+        - restart mqtt_to_telnet_bridge
+
     - name: Enable and start services
       systemd:
         name: "{{ item }}"
@@ -221,6 +257,7 @@
         - mosquitto
         - liquidsoap
         - node-red
+        - mqtt_to_telnet_bridge
 
   handlers:
     - name: reload systemd
@@ -245,4 +282,9 @@
     - name: restart node-red
       systemd:
         name: node-red
-        state: restarted 
+        state: restarted
+
+    - name: restart mqtt_to_telnet_bridge
+      systemd:
+        name: mqtt_to_telnet_bridge
+        state: restarted

--- a/server/liquidsoap/mqtt_to_telnet_bridge.service
+++ b/server/liquidsoap/mqtt_to_telnet_bridge.service
@@ -4,7 +4,8 @@ After=network.target
 
 [Service]
 Type=simple
-User=unix_user
+User=unix
+Group=unix
 WorkingDirectory=/opt/sculpture-system/liquidsoap
 ExecStart=/usr/bin/python3 /opt/sculpture-system/liquidsoap/mqtt_to_telnet_bridge.py
 Restart=on-failure


### PR DESCRIPTION
## Summary
- create a new `unix` user for the MQTT→Telnet bridge
- install bridge script and service via control node playbook
- update service definition to run as `unix`
- mention the bridge in the quick start guide

## Testing
- `ansible-playbook --syntax-check server/ansible/install_control_node.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ea0e1b088331a16773461b992da2