### PR TITLE
Add server setup helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ This system creates a network of three sculptures, each equipped with a Raspberr
    cd yaga2025sculptures
    ```
 
-2. **Follow Setup Guide:**
+2. **Install Server Dependencies:**
+   Run the setup script to install Icecast2, Liquidsoap, Mosquitto, Node.js and other requirements.
+   ```bash
+   sudo ./setup.sh
+   ```
+
+3. **Follow Setup Guide:**
    See [docs/quickstart.md](docs/quickstart.md) for detailed deployment instructions.
 
 ## Repository Structure

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Sculpture System server setup script
+# Installs required packages for Icecast, Liquidsoap, Mosquitto, Node.js and Node-RED
+# Also installs Python dependencies for the MQTT bridge
+set -e
+
+# Ensure the script is run as root
+if [[ $EUID -ne 0 ]]; then
+    echo "Please run as root, e.g. sudo $0" >&2
+    exit 1
+fi
+
+# Move to repo root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+apt update
+
+# Install Node.js repository
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+
+apt update
+
+# Install apt packages
+apt install -y \
+    icecast2 \
+    liquidsoap \
+    mosquitto \
+    mosquitto-clients \
+    nodejs \
+    ansible \
+    python3-pip
+
+# Install Node-RED
+npm install -g node-red
+
+# Install Python requirements
+pip3 install -r server/liquidsoap/requirements.txt
+
+echo "Setup complete"


### PR DESCRIPTION
## Summary
- add a `setup.sh` script to automate installing server dependencies
- document running the script in the Quick Start section of `README.md`

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fef17e4b88331acb9b9c8ee8bb7ba