### PR TITLE
Add basic pytest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ ip addr show eth0
 - Use test tones: `speaker-test -c 1 -t sine`
 - Monitor MQTT: `mosquitto_sub -h server -t '#'`
 - Check audio streams in browser or VLC
+- Run the automated unit tests with `./run_tests.sh`
 
 ## License
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+python3 -m pip install -q pytest
+python3 -m pip install -q -r server/liquidsoap/requirements.txt
+pytest -q

--- a/tests/test_mqtt_to_telnet_bridge.py
+++ b/tests/test_mqtt_to_telnet_bridge.py
@@ -1,0 +1,48 @@
+import importlib.util
+from pathlib import Path
+import asyncio
+import types
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'server/liquidsoap/mqtt_to_telnet_bridge.py'
+
+spec = importlib.util.spec_from_file_location('mqtt_bridge', MODULE_PATH)
+mqtt_bridge = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mqtt_bridge)
+
+
+class DummyWriter:
+    def __init__(self, recorder):
+        self.recorder = recorder
+
+    def write(self, data):
+        self.recorder.append(data)
+
+    async def drain(self):
+        pass
+
+    def close(self):
+        self.recorder.append('closed')
+
+
+async def fake_open_connection(host, port):
+    recorder = []
+    return None, DummyWriter(recorder), recorder
+
+
+def test_send_telnet_command(monkeypatch):
+    records = []
+
+    async def fake_conn(host, port):
+        return None, DummyWriter(records)
+
+    monkeypatch.setattr(mqtt_bridge, 'telnetlib3', types.SimpleNamespace(open_connection=fake_conn))
+
+    async def no_sleep(_):
+        pass
+
+    monkeypatch.setattr(mqtt_bridge.asyncio, 'sleep', no_sleep)
+
+    mqtt_bridge.send_telnet_command('A1')
+
+    assert 'set_plan A1\n' in records
+    assert 'closed' in records

--- a/tests/test_pi_agent.py
+++ b/tests/test_pi_agent.py
@@ -1,0 +1,42 @@
+import importlib.util
+from pathlib import Path
+import types
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'edge/scripts/pi-agent.py'
+
+spec = importlib.util.spec_from_file_location('pi_agent', MODULE_PATH)
+pi_agent = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pi_agent)
+
+
+def test_handle_mute_command(monkeypatch):
+    agent = pi_agent.SculptureAgent()
+    calls = []
+
+    def fake_run(cmd, check=True, **kwargs):
+        calls.append(cmd)
+
+    monkeypatch.setattr(pi_agent.subprocess, 'run', fake_run)
+    agent.handle_mute_command(True)
+
+    assert calls, 'subprocess.run was not called'
+    assert calls[0][0] == 'pactl'
+    assert agent.is_muted is True
+
+
+def test_handle_mode_live(monkeypatch):
+    agent = pi_agent.SculptureAgent()
+    calls = []
+
+    def fake_run(cmd, check=False, **kwargs):
+        calls.append(cmd)
+
+    monkeypatch.setattr(pi_agent.subprocess, 'run', fake_run)
+    agent.handle_mode_command('live')
+
+    joined = ' '.join(' '.join(c) for c in calls)
+    assert 'darkice.service' in joined
+    assert 'player-live.service' in joined
+    assert agent.current_mode == 'live'


### PR DESCRIPTION
## Summary
- create `tests/` with minimal pytest cases for the Pi agent and MQTT bridge
- add `run_tests.sh` helper
- document how to run the tests

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fef1cb4ec833186405decb1c0aa65