### PR TITLE
Add VS Code devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    curl gnupg2 software-properties-common && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get update && apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
+
+# Install system packages mirroring the control node and Pi simulator
+RUN apt-get update && apt-get install -y \
+    icecast2 \
+    liquidsoap \
+    mosquitto \
+    mosquitto-clients \
+    darkice \
+    mpv \
+    python3-paho-mqtt \
+    python3-pip \
+    iproute2 \
+    net-tools \
+    openssh-server \
+    ffmpeg \
+    pulseaudio \
+    pulseaudio-utils \
+    alsa-utils \
+    alsa-oss \
+    libasound2-plugins \
+    nano \
+    htop \
+    sudo && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g node-red
+
+COPY server/liquidsoap/requirements.txt /tmp/requirements.txt
+RUN pip3 install -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+# Create vscode user
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME
+
+USER $USERNAME
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "sculpture-system-dev",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ ip addr show eth0
 - Monitor MQTT: `mosquitto_sub -h server -t '#'`
 - Check audio streams in browser or VLC
 
+### Dev Container
+The `.devcontainer` folder provides a ready-to-use VS Code development
+container. It mirrors the control node and Pi simulator packages so Node.js
+20, Liquidsoap, Mosquitto, Node‑RED and the required Python packages are
+available out of the box. Open the project with the **Remote – Containers**
+extension to develop without installing dependencies locally.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE.md) for details.


### PR DESCRIPTION
## Summary
- include `.devcontainer` with Dockerfile and config
- document how to use the dev container

## Testing
- `python3 -m py_compile server/liquidsoap/mqtt_to_telnet_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_684fef1fcfbc8331a8122bd6aaf3d113