### PR TITLE
Restore audio HAT prep except alsactl restore

### DIFF
--- a/edge/ansible/playbook.yml
+++ b/edge/ansible/playbook.yml
@@ -65,16 +65,6 @@
         dest: "{{ sculpture_dir }}/Pi-Codec"
         version: master
 
-    - name: Restore ALSA state for IQaudIO codec
-      command:
-        argv:
-          - alsactl
-          - --file
-          - >-
-            {{ sculpture_dir }}/Pi-Codec/Codec_Zero_OnboardMIC_record_and_SPK_playback.state
-          - restore
-          - IQaudIOCODEC
-
     - name: Create sculpture system directory
       file:
         path: "{{ sculpture_dir }}"


### PR DESCRIPTION
## Summary
- bring back package updates and HAT setup tasks
- omit the command to restore IQaudIO ALSA state

## Testing
- `bash run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6850030ce7c88331b79df62d8f3a7cb0