### PR TITLE
Install Node-RED dashboard automatically

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -154,21 +154,11 @@ sudo systemctl status mqtt_to_telnet_bridge
 *   **Node-RED:** If Node-RED fails to start:
     1.  Check logs: `sudo journalctl -xeu node-red.service`.
     2.  Common issues include incorrect Node.js version (addressed in Step 9.5) or path issues for the `node-red` executable in `/etc/systemd/system/node-red.service`. Ensure `ExecStart` uses the correct path (usually `/usr/local/bin/node-red` or `/usr/bin/node-red`).
-    3.  **Install `node-red-dashboard` module:** The UI components require this.
+    3.  After resolving issues, restart the service and verify:
         ```bash
-        # In WSL Ubuntu terminal, navigate to Node-RED's working/user directory.
-        # This is often /opt/sculpture-system or a .node-red folder within it,
-        # or /var/lib/node-red, or the home dir of the 'node-red' user.
-        # For this project, /opt/sculpture-system is a good place:
-        cd /opt/sculpture-system
-        sudo npm install node-red-dashboard
-        # Ensure the node-red user owns the installed module:
-        sudo chown -R node-red:node-red /opt/sculpture-system/node_modules
-        # If package-lock.json was created in /opt/sculpture-system:
-        # sudo chown node-red:node-red /opt/sculpture-system/package-lock.json
         sudo systemctl restart node-red
+        sudo systemctl status node-red
         ```
-    4. After restarting, check `sudo systemctl status node-red` again.
 
 ## Step 11: Access Control Dashboard
 

--- a/server/ansible/install_control_node.yml
+++ b/server/ansible/install_control_node.yml
@@ -29,10 +29,21 @@
           - python3-pip
         state: present
 
-    - name: Install Node-RED globally
-      npm:
-        name: node-red
-        global: yes
+  - name: Install Node-RED globally
+    npm:
+      name: node-red
+      global: yes
+
+  - name: Install Node-RED dashboard
+    npm:
+      name: node-red-dashboard
+      path: "{{ sculpture_dir }}"
+      global: no
+      production: yes
+    become_user: node-red
+    notify:
+      - reload systemd
+      - restart node-red
 
     - name: Create sculpture system directory
       file:


### PR DESCRIPTION
## Summary
- add npm task to install `node-red-dashboard`
- notify handlers to reload systemd and restart Node-RED
- remove manual dashboard installation steps from quickstart docs

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685016bf73988331af3083c02a865f6a