### PR TITLE
Fix Node-RED dashboard install in Ansible playbook

### DIFF
--- a/server/ansible/install_control_node.yml
+++ b/server/ansible/install_control_node.yml
@@ -34,6 +34,14 @@
         name: node-red
         global: yes
 
+    - name: Create node-red user
+      user:
+        name: node-red
+        system: yes
+        shell: /bin/false
+        home: /opt/sculpture-system
+        create_home: no
+
     - name: Install Node-RED dashboard
       npm:
         name: node-red-dashboard
@@ -162,14 +170,6 @@
       notify:
         - reload systemd
         - restart node-red
-
-    - name: Create node-red user
-      user:
-        name: node-red
-        system: yes
-        shell: /bin/false
-        home: /opt/sculpture-system
-        create_home: no
 
     - name: Create unix user for MQTT bridge
       user:


### PR DESCRIPTION
## Summary
- create `node-red` user before installing the dashboard

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68501dafe8508331a70b030860509bb8