### PR TITLE
Disable wifi powersave on Pis

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -88,6 +88,8 @@ ansible-playbook -i edge/ansible/hosts.ini edge/ansible/playbook.yml
 ansible sculptures -i edge/ansible/hosts.ini -m ping
 ```
 
+Running this playbook also disables WiFi power saving on each Pi by creating `/etc/NetworkManager/conf.d/wifi-powersave.conf`.
+
 ## Step 8: Pre-configure Icecast Hostname (Critical)
 
 Before you install the control node services, you must configure the Icecast server template. This ensures that when Icecast is installed, it's already set up to allow other devices on your network (like the Raspberry Pis) to connect to the audio streams.

--- a/edge/ansible/playbook.yml
+++ b/edge/ansible/playbook.yml
@@ -28,6 +28,17 @@
           - git
         state: present
 
+    - name: Disable WiFi power saving
+      copy:
+        dest: /etc/NetworkManager/conf.d/wifi-powersave.conf
+        content: |
+          [connection]
+          wifi.powersave = 2
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Restart NetworkManager
+
     - name: Detect firmware config path
       stat:
         path: /boot/firmware/config.txt
@@ -224,4 +235,9 @@
       systemd:
         daemon_reload: yes
         name: pi-agent.service
+        state: restarted
+
+    - name: Restart NetworkManager
+      systemd:
+        name: NetworkManager.service
         state: restarted

--- a/tests/test_pi_agent.py
+++ b/tests/test_pi_agent.py
@@ -45,7 +45,7 @@ def test_handle_mode_live(monkeypatch):
 def test_cpu_parse_error_included(monkeypatch):
     agent = pi_agent.SculptureAgent()
 
-    def fake_run(cmd, capture_output=True, text=True, check=True):
+    def fake_run(cmd, capture_output=True, text=True, check=True, **kwargs):
         if cmd[0] == 'top':
             return types.SimpleNamespace(stdout="Cpu(s): us,\n")
         elif cmd[0] == 'vcgencmd':


### PR DESCRIPTION
## Summary
- disable wifi power management in edge playbook
- restart NetworkManager when that config is written
- document wifi powersave disablement in Raspberry Pi setup docs
- update tests for latest pi-agent behavior

## Testing
- `bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854288dcc9483319698d00438a38714