### PR TITLE
Switch to 44.1kHz audio

### DIFF
--- a/docker/pi-simulator/audio-simulator.sh
+++ b/docker/pi-simulator/audio-simulator.sh
@@ -48,7 +48,7 @@ while true; do
     
     # Generate audio and pipe to PulseAudio
     ffmpeg -f lavfi -i "${PATTERN}=frequency=${CURRENT_FREQ}:duration=30" \
-           -f pulse -ac 1 -ar 48000 \
+           -f pulse -ac 1 -ar 44100 \
            sculpture_source 2>/dev/null &
     
     # Wait and add some silence for realism
@@ -56,7 +56,7 @@ while true; do
     
     # Add 5 seconds of quiet (simulating ambient noise)
     ffmpeg -f lavfi -i "anoisesrc=duration=5:color=white:amplitude=0.1" \
-           -f pulse -ac 1 -ar 48000 \
+           -f pulse -ac 1 -ar 44100 \
            sculpture_source 2>/dev/null &
     
     sleep 5

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -113,7 +113,7 @@ On each Pi:
 
 1. `sudo alsactl --file Codec_Zero_OnboardMIC_record_and_SPK_playback.state restore IQaudIOCODEC`
 2. *(optional)* `sudo alsactl store`
-3. Test: `arecord -D hw:1,0 -f S16_LE -c 2 -r 48000 -d 5 test.wav && aplay -D hw:1,0`
+3. Test: `arecord -D hw:1,0 -f S16_LE -c 2 -r 44100 -d 5 test.wav && aplay -D hw:1,0`
 4. Copy to wsl: `scp pi@sculptureX:~/test.wav .` and check for sound
 
 ## Step 10: Install Control Node Services

--- a/server/liquidsoap/main.liq
+++ b/server/liquidsoap/main.liq
@@ -15,7 +15,7 @@ settings.server.telnet.bind_addr.set("0.0.0.0")
 settings.server.telnet.port.set(1234)
 
 # Audio settings
-settings.frame.audio.samplerate.set(48000)
+settings.frame.audio.samplerate.set(44100)
 # settings.frame.audio.channels.set(1) # Let liquidsoap handle channels dynamically
 
 # Input sources from sculptures


### PR DESCRIPTION
## Summary
- set Liquidsoap to 44.1 kHz
- update docs to recommend recording at 44.1 kHz
- adjust Pi simulator sample rate to 44.1 kHz

## Testing
- `pytest -q` *(fails: test_cpu_parse_error_included)*

------
https://chatgpt.com/codex/tasks/task_e_6854288cdff483319040f6a42454787d