### PR TITLE
Update mpv cache duration

### DIFF
--- a/edge/systemd/player-live.service.j2
+++ b/edge/systemd/player-live.service.j2
@@ -6,7 +6,7 @@ Requires=sound.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/mpv --no-video --audio-device=pulse/sculpture_sink --cache=yes --demuxer-max-bytes=5M --audio-buffer=2 http://{{ control_host }}:8000/mix-for-{{ id }}.ogg
+ExecStart=/usr/bin/mpv --no-video --audio-device=pulse/sculpture_sink --cache=yes --cache-secs=10 --demuxer-max-bytes=5M --audio-buffer=2 http://{{ control_host }}:8000/mix-for-{{ id }}.ogg
 Restart=always
 RestartSec=5
 User=pi


### PR DESCRIPTION
## Summary
- add `--cache-secs=10` to the mpv invocation in `player-live.service.j2`

## Testing
- `./run_tests.sh` *(fails: test_cpu_parse_error_included)*

------
https://chatgpt.com/codex/tasks/task_e_6854288bbb64833194294e79d9311e9f